### PR TITLE
Add AutoColumnSize constructor externs

### DIFF
--- a/src/slickgrid-externs.js
+++ b/src/slickgrid-externs.js
@@ -1567,3 +1567,8 @@ Slick.Controls = {};
  * @constructor
  */
 Slick.Controls.Pager = function(dataview, grid, jqueryElement) {};
+
+/**
+ * @constructor
+ */
+Slick.AutoColumnSize = function() {};


### PR DESCRIPTION
The lack of it affected table rendering on prod mode.
